### PR TITLE
fix: run CI checks on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: Build
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   no-uncommitted-changes:


### PR DESCRIPTION
This runs checks on PRs too (crucial for checking external contributions)

> ![2020-07-28--16-01-38](https://user-images.githubusercontent.com/157609/88675846-af96a980-d0eb-11ea-9ca9-ceae2fa8f241.png)
